### PR TITLE
Update flake and package.json

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1734808813,
-        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "lastModified": 1737689766,
+        "narHash": "sha256-ivVXYaYlShxYoKfSo5+y5930qMKKJ8CLcAoIBPQfJ6s=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
+        "rev": "6fe74265bbb6d016d663b1091f015e2976c4a527",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -297,19 +297,34 @@
         "type": "github"
       }
     },
+    "hds-releases": {
+      "locked": {
+        "lastModified": 1738232131,
+        "narHash": "sha256-aSjaykDi7MKj9rugkJwrPXyGPv1ysALVpVa+zctQmWI=",
+        "owner": "holo-host",
+        "repo": "hds-releases",
+        "rev": "08b7d0dfb256f721900a3f04a1552c4714fcbffa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holo-host",
+        "repo": "hds-releases",
+        "type": "github"
+      }
+    },
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1734458780,
-        "narHash": "sha256-v06NZ0VWiGSC6+JfnQ0qCmjEhSOfdwG76dxzJ2fgh7Y=",
+        "lastModified": 1728079169,
+        "narHash": "sha256-sbQiTsh5dhI8ioQIfYkdNsCQCCT+vef+RhXumvYiVQQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "f9311904e553e56e6622a978853974892d83e23e",
+        "rev": "d2868417b921850206247595f0e00d6eaf1b84f2",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.4.0",
+        "ref": "holochain-0.4.0-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -360,11 +375,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1736528178,
-        "narHash": "sha256-9GKmqS5Mgz6PTgj/4ZOEiDRlJ0GBGAsa2KOeOMK0VVI=",
+        "lastModified": 1738173723,
+        "narHash": "sha256-Iaa0fi8Q1r3hb4T0NMcBELdJDTPYNdTNIEwfEGX1NmE=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "479490784dc96c3888d898a3c997921732c9806d",
+        "rev": "2e2ae48f218a0084fa78174d76fa638eb3d40c34",
         "type": "github"
       },
       "original": {
@@ -429,16 +444,16 @@
     "lair-keystore": {
       "flake": false,
       "locked": {
-        "lastModified": 1732721902,
-        "narHash": "sha256-D8sXIpOptaXib5bc6zS7KsGzu4D08jaL8Fx1W/mlADE=",
+        "lastModified": 1726865440,
+        "narHash": "sha256-+ARQs+Sfmh8QXMyjjHjm6Ib8Ag86Jm2vnyB6l3zTCgA=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "e82937521ae9b7bdb30c8b0736c13cd4220a0223",
+        "rev": "9f306efed597765b70da704e1739ecc67f2510e0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.5.3",
+        "ref": "lair_keystore-v0.5.2",
         "repo": "lair",
         "type": "github"
       }
@@ -479,11 +494,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
         "type": "github"
       },
       "original": {
@@ -495,14 +510,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -620,6 +635,7 @@
           "holonix",
           "flake-parts"
         ],
+        "hds-releases": "hds-releases",
         "holonix": "holonix",
         "nixpkgs": [
           "holonix",
@@ -636,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734834660,
-        "narHash": "sha256-bm8V+Cu8rWJA+vKQnc94mXTpSDgvedyoDKxTVi/uJfw=",
+        "lastModified": 1738117527,
+        "narHash": "sha256-GFviGfaezjGLFUlxdv3zyC7rSZvTXqwcG/YsF6MDkOw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b070e6030118680977bc2388868c4b3963872134",
+        "rev": "6a3dc6ce4132bd57359214d986db376f2333c14d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,14 @@
 
   inputs = {
     holonix.url = "github:holochain/holonix/main-0.4";
+    holonix.inputs.holochain.url = "github:holochain/holochain?ref=holochain-0.4.0-rc.0";
+    holonix.inputs.lair-keystore.url = "github:holochain/lair?ref=lair_keystore-v0.5.2";
 
     nixpkgs.follows = "holonix/nixpkgs";
     flake-parts.follows = "holonix/flake-parts";
 
+    hds-releases.url = "github:holo-host/hds-releases";
+    
     p2p-shipyard.url = "github:darksoil-studio/p2p-shipyard/main-0.4";
   };
 
@@ -18,7 +22,12 @@
           inputsFrom = [ 
             inputs'.p2p-shipyard.devShells.holochainTauriDev 
             inputs'.holonix.devShells.default
+            # inputs'.hds-releases.packages.holo-dev-server-bin
           ];
+
+          packages = (with pkgs; [
+            inputs'.hds-releases.packages.holo-dev-server-bin
+          ]);
         };
         devShells.androidDev = pkgs.mkShell {
           inputsFrom = [ 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,7 +6882,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@holo-host/web-sdk": "^0.6.20-prerelease",
-        "@holochain/client": "0.18.0-dev.2",
+        "@holochain/client": "0.18.0",
         "@material/mwc-button": "^0.27.0",
         "@material/mwc-checkbox": "^0.27.0",
         "@material/mwc-circular-progress": "^0.27.0",
@@ -6904,25 +6904,6 @@
         "vite": "^4.0.4",
         "vite-plugin-checker": "^0.5.1",
         "vue-tsc": "^1.0.24"
-      }
-    },
-    "ui/node_modules/@holochain/client": {
-      "version": "0.18.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.2.tgz",
-      "integrity": "sha512-SpmGdmyRZlWg9TBoXCdqoU65xb7ScpWXYpTwnTu8Ppe43Q+KbFzgTBlpsWNJI28hIVDEWh0I9xVS4kNPKa4plw==",
-      "dependencies": {
-        "@bitgo/blake2b": "^3.2.4",
-        "@holochain/serialization": "^0.1.0-beta-rc.3",
-        "@msgpack/msgpack": "^2.8.0",
-        "emittery": "^1.0.1",
-        "isomorphic-ws": "^5.0.0",
-        "js-base64": "^3.7.5",
-        "libsodium-wrappers": "^0.7.13",
-        "lodash-es": "^4.17.21",
-        "ws": "^8.14.2"
-      },
-      "engines": {
-        "node": ">=18.0.0 || >=20.0.0"
       }
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,11 +5,12 @@
     "start": "vite --port $UI_PORT --clearScreen false",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && cd dist && bestzip ../dist.zip *",
+    "serve:local": "VITE_APP_IS_HOLO='true' VITE_APP_CHAPERONE_URL='http://localhost:24274' vite"
   },
   "dependencies": {
     "@holo-host/web-sdk": "^0.6.20-prerelease",
-    "@holochain/client": "0.18.0-dev.2",
+    "@holochain/client": "0.18.0",
     "@material/mwc-button": "^0.27.0",
     "@material/mwc-checkbox": "^0.27.0",
     "@material/mwc-circular-progress": "^0.27.0",


### PR DESCRIPTION
This results in a working happ running with holo dev server for me. Note that holochain and holo-dev-server here version 0.4.0-rc.0 BUT the hApp itself is built with 0.4.0 so you won't need to recompile.

To test you'll want to do the following

```
nix flake update # update the flake.lock
nix develop # enter shell
npm run network:holo # spawn backend running with holo-dev-server + holochain playground
cd ui && npm install && npm run serve:holo # serve UI pointing to local chaperone and holo-dev-server
```

